### PR TITLE
Changing reg_rate default

### DIFF
--- a/src/model/train.py
+++ b/src/model/train.py
@@ -64,7 +64,7 @@ def parse_args():  # sourcery skip: inline-immediately-returned-variable
     parser.add_argument("--training_data", dest='training_data',
                         type=str)
     parser.add_argument("--reg_rate", dest='reg_rate',
-                        type=float, default=0.01)
+                        type=float, default=0.005)
 
     # parse args
     args = parser.parse_args()


### PR DESCRIPTION
Change default reg_rate.

## Summary by Sourcery

Enhancements:
- Reduce default reg_rate value from 0.01 to 0.005 in the argument parser.