### PR TITLE
Revert "Changing reg_rate default"

### DIFF
--- a/src/model/train.py
+++ b/src/model/train.py
@@ -64,7 +64,7 @@ def parse_args():  # sourcery skip: inline-immediately-returned-variable
     parser.add_argument("--training_data", dest='training_data',
                         type=str)
     parser.add_argument("--reg_rate", dest='reg_rate',
-                        type=float, default=0.005)
+                        type=float, default=0.01)
 
     # parse args
     args = parser.parse_args()


### PR DESCRIPTION
Reverts BanTheMan/MLops_challenges#1

## Summary by Sourcery

Bug Fixes:
- Restore default reg_rate value to 0.01 in train.py